### PR TITLE
Add Flutter reaction game skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# game
+# Game Repository
+
+This repository contains a simple Flutter project demonstrating a reaction time game built with BLoC.
+
+The game source code lives under the `flutter_game` directory. To run the project locally, ensure you have Flutter installed and execute:
+
+```bash
+flutter pub get
+flutter run
+```
+
+The application measures how quickly you tap the screen once it turns green. It uses the `flutter_bloc` package to manage game state.

--- a/flutter_game/README.md
+++ b/flutter_game/README.md
@@ -1,0 +1,16 @@
+# Flutter Reaction Game
+
+A simple Flutter game that tests your reaction time. The project demonstrates the use of the BLoC pattern.
+
+## Running
+
+Ensure you have Flutter installed. From the `flutter_game` directory run:
+
+```bash
+flutter pub get
+flutter run
+```
+
+## Gameplay
+
+Press **Start** and wait until the screen turns green, then tap as quickly as possible. Your reaction time is displayed and you can play again.

--- a/flutter_game/lib/bloc/reaction_bloc.dart
+++ b/flutter_game/lib/bloc/reaction_bloc.dart
@@ -1,0 +1,39 @@
+import 'dart:async';
+import 'dart:math';
+
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+
+part 'reaction_event.dart';
+part 'reaction_state.dart';
+
+class ReactionBloc extends Bloc<ReactionEvent, ReactionState> {
+  ReactionBloc() : super(const ReactionInitial()) {
+    on<StartGame>(_onStart);
+    on<UserTapped>(_onTap);
+    on<ResetGame>(_onReset);
+  }
+
+  Timer? _timer;
+  late DateTime _startTime;
+
+  Future<void> _onStart(StartGame event, Emitter<ReactionState> emit) async {
+    emit(const ReactionWaiting());
+    final delay = Random().nextInt(2000) + 1000;
+    await Future.delayed(Duration(milliseconds: delay));
+    _startTime = DateTime.now();
+    emit(const ReactionRunning());
+  }
+
+  void _onTap(UserTapped event, Emitter<ReactionState> emit) {
+    if (state is ReactionRunning) {
+      final reactionTime = DateTime.now().difference(_startTime);
+      emit(ReactionResult(reactionTime));
+    }
+  }
+
+  void _onReset(ResetGame event, Emitter<ReactionState> emit) {
+    _timer?.cancel();
+    emit(const ReactionInitial());
+  }
+}

--- a/flutter_game/lib/bloc/reaction_event.dart
+++ b/flutter_game/lib/bloc/reaction_event.dart
@@ -1,0 +1,20 @@
+part of 'reaction_bloc.dart';
+
+abstract class ReactionEvent extends Equatable {
+  const ReactionEvent();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class StartGame extends ReactionEvent {
+  const StartGame();
+}
+
+class UserTapped extends ReactionEvent {
+  const UserTapped();
+}
+
+class ResetGame extends ReactionEvent {
+  const ResetGame();
+}

--- a/flutter_game/lib/bloc/reaction_state.dart
+++ b/flutter_game/lib/bloc/reaction_state.dart
@@ -1,0 +1,29 @@
+part of 'reaction_bloc.dart';
+
+abstract class ReactionState extends Equatable {
+  const ReactionState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class ReactionInitial extends ReactionState {
+  const ReactionInitial();
+}
+
+class ReactionWaiting extends ReactionState {
+  const ReactionWaiting();
+}
+
+class ReactionRunning extends ReactionState {
+  const ReactionRunning();
+}
+
+class ReactionResult extends ReactionState {
+  final Duration reactionTime;
+
+  const ReactionResult(this.reactionTime);
+
+  @override
+  List<Object?> get props => [reactionTime];
+}

--- a/flutter_game/lib/main.dart
+++ b/flutter_game/lib/main.dart
@@ -1,0 +1,24 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'bloc/reaction_bloc.dart';
+import 'screens/home_screen.dart';
+
+void main() {
+  runApp(const ReactionGameApp());
+}
+
+class ReactionGameApp extends StatelessWidget {
+  const ReactionGameApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Reaction Game',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: BlocProvider(
+        create: (_) => ReactionBloc(),
+        child: const HomeScreen(),
+      ),
+    );
+  }
+}

--- a/flutter_game/lib/screens/home_screen.dart
+++ b/flutter_game/lib/screens/home_screen.dart
@@ -1,0 +1,47 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../bloc/reaction_bloc.dart';
+
+class HomeScreen extends StatelessWidget {
+  const HomeScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reaction Game')),
+      body: Center(
+        child: BlocBuilder<ReactionBloc, ReactionState>(
+          builder: (context, state) {
+            if (state is ReactionInitial) {
+              return ElevatedButton(
+                onPressed: () => context.read<ReactionBloc>().add(const StartGame()),
+                child: const Text('Start'),
+              );
+            } else if (state is ReactionWaiting) {
+              return const Text('Wait for green...');
+            } else if (state is ReactionRunning) {
+              return GestureDetector(
+                onTap: () => context.read<ReactionBloc>().add(const UserTapped()),
+                child: Container(color: Colors.green, width: 200, height: 200),
+              );
+            } else if (state is ReactionResult) {
+              return Column(
+                mainAxisSize: MainAxisSize.min,
+                children: [
+                  Text('Your time: ${state.reactionTime.inMilliseconds} ms'),
+                  const SizedBox(height: 16),
+                  ElevatedButton(
+                    onPressed: () => context.read<ReactionBloc>().add(const ResetGame()),
+                    child: const Text('Play Again'),
+                  ),
+                ],
+              );
+            } else {
+              return const SizedBox.shrink();
+            }
+          },
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_game/pubspec.yaml
+++ b/flutter_game/pubspec.yaml
@@ -1,0 +1,21 @@
+name: flutter_game
+version: 0.1.0
+publish_to: none
+description: A simple reaction time game using Flutter BLoC.
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+  flutter: '>=3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  flutter_bloc: ^8.1.1
+  equatable: ^2.0.5
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- bootstrap a `flutter_game` project
- implement a simple reaction time game using BLoC
- document how to run the project

## Testing
- `flutter --version` *(fails: command not found)*
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684effaa8c488330a0421e2c1ddef818