### PR TITLE
Add persistent high score

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,4 +9,4 @@ flutter pub get
 flutter run
 ```
 
-The application measures how quickly you tap the screen once it turns green. It uses the `flutter_bloc` package to manage game state.
+The application measures how quickly you tap the screen once it turns green. It uses the `flutter_bloc` package to manage game state. Your best reaction time is stored locally so you can challenge yourself to improve.

--- a/flutter_game/README.md
+++ b/flutter_game/README.md
@@ -13,4 +13,4 @@ flutter run
 
 ## Gameplay
 
-Press **Start** and wait until the screen turns green, then tap as quickly as possible. Your reaction time is displayed and you can play again.
+Press **Start** and wait until the screen turns green, then tap as quickly as possible. Your reaction time is displayed and stored as a high score if it's your best so far.

--- a/flutter_game/lib/bloc/high_score_cubit.dart
+++ b/flutter_game/lib/bloc/high_score_cubit.dart
@@ -1,0 +1,26 @@
+import 'package:bloc/bloc.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class HighScoreCubit extends Cubit<Duration?> {
+  HighScoreCubit() : super(null) {
+    _loadHighScore();
+  }
+
+  static const _key = 'high_score_ms';
+
+  Future<void> _loadHighScore() async {
+    final prefs = await SharedPreferences.getInstance();
+    final ms = prefs.getInt(_key);
+    if (ms != null) {
+      emit(Duration(milliseconds: ms));
+    }
+  }
+
+  Future<void> updateScore(Duration newScore) async {
+    if (state == null || newScore.inMilliseconds < state!.inMilliseconds) {
+      emit(newScore);
+      final prefs = await SharedPreferences.getInstance();
+      await prefs.setInt(_key, newScore.inMilliseconds);
+    }
+  }
+}

--- a/flutter_game/lib/bloc/reaction_bloc.dart
+++ b/flutter_game/lib/bloc/reaction_bloc.dart
@@ -3,12 +3,15 @@ import 'dart:math';
 
 import 'package:bloc/bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'high_score_cubit.dart';
 
 part 'reaction_event.dart';
 part 'reaction_state.dart';
 
 class ReactionBloc extends Bloc<ReactionEvent, ReactionState> {
-  ReactionBloc() : super(const ReactionInitial()) {
+  final HighScoreCubit highScoreCubit;
+
+  ReactionBloc(this.highScoreCubit) : super(const ReactionInitial()) {
     on<StartGame>(_onStart);
     on<UserTapped>(_onTap);
     on<ResetGame>(_onReset);
@@ -29,6 +32,7 @@ class ReactionBloc extends Bloc<ReactionEvent, ReactionState> {
     if (state is ReactionRunning) {
       final reactionTime = DateTime.now().difference(_startTime);
       emit(ReactionResult(reactionTime));
+      unawaited(highScoreCubit.updateScore(reactionTime));
     }
   }
 

--- a/flutter_game/lib/main.dart
+++ b/flutter_game/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'bloc/reaction_bloc.dart';
+import 'bloc/high_score_cubit.dart';
 import 'screens/home_screen.dart';
 
 void main() {
@@ -15,8 +16,11 @@ class ReactionGameApp extends StatelessWidget {
     return MaterialApp(
       title: 'Reaction Game',
       theme: ThemeData(primarySwatch: Colors.blue),
-      home: BlocProvider(
-        create: (_) => ReactionBloc(),
+      home: MultiBlocProvider(
+        providers: [
+          BlocProvider(create: (_) => HighScoreCubit()),
+          BlocProvider(create: (context) => ReactionBloc(context.read<HighScoreCubit>())),
+        ],
         child: const HomeScreen(),
       ),
     );

--- a/flutter_game/lib/screens/home_screen.dart
+++ b/flutter_game/lib/screens/home_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import '../bloc/reaction_bloc.dart';
+import '../bloc/high_score_cubit.dart';
 
 class HomeScreen extends StatelessWidget {
   const HomeScreen({super.key});
@@ -10,36 +11,50 @@ class HomeScreen extends StatelessWidget {
     return Scaffold(
       appBar: AppBar(title: const Text('Reaction Game')),
       body: Center(
-        child: BlocBuilder<ReactionBloc, ReactionState>(
-          builder: (context, state) {
-            if (state is ReactionInitial) {
-              return ElevatedButton(
-                onPressed: () => context.read<ReactionBloc>().add(const StartGame()),
-                child: const Text('Start'),
-              );
-            } else if (state is ReactionWaiting) {
-              return const Text('Wait for green...');
-            } else if (state is ReactionRunning) {
-              return GestureDetector(
-                onTap: () => context.read<ReactionBloc>().add(const UserTapped()),
-                child: Container(color: Colors.green, width: 200, height: 200),
-              );
-            } else if (state is ReactionResult) {
-              return Column(
-                mainAxisSize: MainAxisSize.min,
-                children: [
-                  Text('Your time: ${state.reactionTime.inMilliseconds} ms'),
-                  const SizedBox(height: 16),
-                  ElevatedButton(
-                    onPressed: () => context.read<ReactionBloc>().add(const ResetGame()),
-                    child: const Text('Play Again'),
-                  ),
-                ],
-              );
-            } else {
-              return const SizedBox.shrink();
-            }
-          },
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            BlocBuilder<HighScoreCubit, Duration?>(
+              builder: (context, bestTime) {
+                final text = bestTime == null
+                    ? 'No high score yet'
+                    : 'Best time: ${bestTime.inMilliseconds} ms';
+                return Text(text);
+              },
+            ),
+            const SizedBox(height: 32),
+            BlocBuilder<ReactionBloc, ReactionState>(
+              builder: (context, state) {
+                if (state is ReactionInitial) {
+                  return ElevatedButton(
+                    onPressed: () => context.read<ReactionBloc>().add(const StartGame()),
+                    child: const Text('Start'),
+                  );
+                } else if (state is ReactionWaiting) {
+                  return const Text('Wait for green...');
+                } else if (state is ReactionRunning) {
+                  return GestureDetector(
+                    onTap: () => context.read<ReactionBloc>().add(const UserTapped()),
+                    child: Container(color: Colors.green, width: 200, height: 200),
+                  );
+                } else if (state is ReactionResult) {
+                  return Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: [
+                      Text('Your time: ${state.reactionTime.inMilliseconds} ms'),
+                      const SizedBox(height: 16),
+                      ElevatedButton(
+                        onPressed: () => context.read<ReactionBloc>().add(const ResetGame()),
+                        child: const Text('Play Again'),
+                      ),
+                    ],
+                  );
+                } else {
+                  return const SizedBox.shrink();
+                }
+              },
+            ),
+          ],
         ),
       ),
     );

--- a/flutter_game/pubspec.yaml
+++ b/flutter_game/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
     sdk: flutter
   flutter_bloc: ^8.1.1
   equatable: ^2.0.5
+  shared_preferences: ^2.0.15
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add shared_preferences to dependencies
- create `HighScoreCubit` for persisting best reaction time
- integrate `HighScoreCubit` with `ReactionBloc`
- display best score on the home screen
- document new feature in READMEs

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684f03acd04c83309d84b70503b2179a